### PR TITLE
feat: Add promotion environments

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -45,6 +45,7 @@ func Main() (*cobra.Command, *promote.Options) {
 
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "The Namespace to promote to")
 	cmd.Flags().StringVarP(&options.Environment, opts.OptionEnvironment, "e", "", "The Environment to promote to")
+	cmd.Flags().StringArrayP("promotion-environments", "", options.PromoteEnvironments, "The environments considered for promotion")
 	cmd.Flags().BoolVarP(&options.AllAutomatic, "all-auto", "", false, "Promote to all automatic environments in order")
 	cmd.Flags().BoolVarP(&options.BatchMode, "batch-mode", "b", false, "Enables batch mode which avoids prompting for user input")
 


### PR DESCRIPTION
Adds flag to specify environments that can be used for promotion. This flag ignores whether environment ignore environment promotion strategy.

/assign @jstrachan