### PR TITLE
fix: Promote to multiple Auto remote environments

### DIFF
--- a/pkg/environments/gitops.go
+++ b/pkg/environments/gitops.go
@@ -88,8 +88,9 @@ func (o *EnvironmentPullRequestOptions) Create(gitURL, prDir string, pullRequest
 		return nil, errors.Wrapf(err, "failed to invoke change function in dir %s", dir)
 	}
 
+	o.Labels = nil
 	// lets merge any labels together...
-	if autoMerge && stringhelpers.StringArrayIndex(o.Labels, LabelUpdatebot) < 0 {
+	if autoMerge {
 		o.Labels = append(o.Labels, LabelUpdatebot)
 	}
 	for _, l := range pullRequestDetails.Labels {

--- a/pkg/promote/promote.go
+++ b/pkg/promote/promote.go
@@ -547,7 +547,6 @@ func (o *Options) PromoteAll(pred func(*v1.Environment) bool) error {
 	}
 	jxenv.SortEnvironments(environments)
 
-	count := 0
 	for _, env := range environments {
 		if pred(&env) {
 			ns := env.Spec.Namespace
@@ -556,7 +555,7 @@ func (o *Options) PromoteAll(pred func(*v1.Environment) bool) error {
 			}
 			// lets clear the branch name so that we create a new branch for each PR...
 			o.BranchName = ""
-			releaseInfo, err := o.Promote(ns, &env, false, count > 0, o.NoPoll)
+			releaseInfo, err := o.Promote(ns, &env, false, env.Spec.PromotionStrategy != v1.PromotionStrategyTypeAutomatic, o.NoPoll)
 			if err != nil {
 				return err
 			}
@@ -567,7 +566,6 @@ func (o *Options) PromoteAll(pred func(*v1.Environment) bool) error {
 					return err
 				}
 			}
-			count++
 		}
 	}
 	return nil

--- a/pkg/rules/helmfile/helmfile_rule.go
+++ b/pkg/rules/helmfile/helmfile_rule.go
@@ -78,7 +78,8 @@ func modifyHelmfile(r *rules.PromoteRule, rule *v1alpha1.HelmfileRule, file stri
 	}
 	nestedPath := rule.Path
 	for _, s := range rootState.Helmfiles {
-		if s.Path == nestedPath {
+		matches, err := filepath.Match(s.Path, nestedPath)
+		if err == nil && matches {
 			return nil
 		}
 	}


### PR DESCRIPTION
- The promotion to remote clusters was using `Cluster.Namespace` from jxRequirements. If we use the namespace from `Environment`, we can have multiple environments in a remote cluster.
- Promotion to auto environments were applying the draft label except for the first one. Let's not do that if PromotionStrategy is Auto. Even that check maybe unnecessary for PromoteAll.
- Labels were getting appended cumulatively for each environment. So let's clear the labels before appending for each env.
- Use `filepath.Match` instead of strict equality to verify that nested helmfiles are referenced in the root helmfile. This will allow for GLOB patterns.
- Remove 'environment' from the commit message for promotion to keep it concise.

fixes #164 #165 #166
