### PR TITLE
Helmfile keep old releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ docs/apidocs/static/scroll.js
 pkg/jx/cmd/verify-pod.log
 
 plugin.gz
+
+# store for vscode local history plugin : https://marketplace.visualstudio.com/items?itemName=xyz.local-history
+.history

--- a/pkg/apis/promote/v1alpha1/types.go
+++ b/pkg/apis/promote/v1alpha1/types.go
@@ -51,6 +51,9 @@ type HelmfileRule struct {
 	// Namespace if specified the given namespace is used in the `helmfile.yml` file when using Environments in the
 	// same cluster using the same git repository URL as the dev environment
 	Namespace string `json:"namespace"`
+
+	// KeepOldReleases if specified will cause the old releases to be retailed in the helfile
+	KeepOldReleases bool `json:"keepOldReleases"`
 }
 
 // KptRule specifies to fetch the apps resource via kpt : https://googlecontainertools.github.io/kpt/

--- a/pkg/rules/factory/factory_test.go
+++ b/pkg/rules/factory/factory_test.go
@@ -3,6 +3,7 @@ package factory_test
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jenkins-x/jx-helpers/v3/pkg/files"
@@ -78,7 +79,7 @@ func TestRuleFactory(t *testing.T) {
 
 			testhelpers.AssertTextFilesEqual(t, filepath.Join(src, fileName+".2.expected"), target, fileName)
 
-			if name == "helmfile-nested" {
+			if strings.HasPrefix(name, "helmfile-nested") {
 				testhelpers.AssertTextFilesEqual(t, filepath.Join(src, "helmfile.yaml.expected"), filepath.Join(dir, "helmfile.yaml"), fileName)
 			}
 		}

--- a/pkg/rules/factory/test_data/helmfile-explicit-keep-old-releases/.jx/promote.yaml
+++ b/pkg/rules/factory/test_data/helmfile-explicit-keep-old-releases/.jx/promote.yaml
@@ -1,0 +1,6 @@
+apiVersion: promote.jenkins-x.io/v1alpha1
+kind: Promote
+spec:
+  helmfileRule:
+    path: helmfile.yaml
+    keepOldReleases: true

--- a/pkg/rules/factory/test_data/helmfile-explicit-keep-old-releases/helmfile.yaml
+++ b/pkg/rules/factory/test_data/helmfile-explicit-keep-old-releases/helmfile.yaml
@@ -1,0 +1,8 @@
+repositories:
+- name: yourorg
+  url: https://yourorg.example.com/charts
+releases:
+- name: dbmigrator
+  labels:
+    job: dbmigrator
+  chart: ./dbmigrator

--- a/pkg/rules/factory/test_data/helmfile-explicit-keep-old-releases/helmfile.yaml.1.expected
+++ b/pkg/rules/factory/test_data/helmfile-explicit-keep-old-releases/helmfile.yaml.1.expected
@@ -1,0 +1,17 @@
+filepath: ""
+repositories:
+- name: yourorg
+  url: https://yourorg.example.com/charts
+- name: dev
+  url: http://chartmuseum-jx.34.78.195.22.nip.io
+releases:
+- chart: ./dbmigrator
+  name: dbmigrator
+  labels:
+    job: dbmigrator
+- chart: dev/myapp
+  version: 1.2.3
+  name: myapp
+  namespace: jx
+templates: {}
+renderedvalues: {}

--- a/pkg/rules/factory/test_data/helmfile-explicit-keep-old-releases/helmfile.yaml.2.expected
+++ b/pkg/rules/factory/test_data/helmfile-explicit-keep-old-releases/helmfile.yaml.2.expected
@@ -1,0 +1,21 @@
+filepath: ""
+repositories:
+- name: yourorg
+  url: https://yourorg.example.com/charts
+- name: dev
+  url: http://chartmuseum-jx.34.78.195.22.nip.io
+releases:
+- chart: ./dbmigrator
+  name: dbmigrator
+  labels:
+    job: dbmigrator
+- chart: dev/myapp
+  version: 1.2.3
+  name: myapp
+  namespace: jx
+- chart: dev/myapp
+  version: 1.2.4
+  name: myapp
+  namespace: jx
+templates: {}
+renderedvalues: {}

--- a/pkg/rules/factory/test_data/helmfile-nested-explicit-keep-old-releases/.jx/promote.yaml
+++ b/pkg/rules/factory/test_data/helmfile-nested-explicit-keep-old-releases/.jx/promote.yaml
@@ -1,0 +1,6 @@
+apiVersion: promote.jenkins-x.io/v1alpha1
+kind: Promote
+spec:
+  helmfileRule:
+    path: helmfiles/jx/helmfile.yaml
+    keepOldReleases: true

--- a/pkg/rules/factory/test_data/helmfile-nested-explicit-keep-old-releases/helmfile.yaml
+++ b/pkg/rules/factory/test_data/helmfile-nested-explicit-keep-old-releases/helmfile.yaml
@@ -1,0 +1,7 @@
+filepath: ""
+helmfiles:
+- path: helmfiles/nginx/helmfile.yaml
+  environment: {}
+templates: {}
+missingFileHandler: ""
+renderedvalues: {}

--- a/pkg/rules/factory/test_data/helmfile-nested-explicit-keep-old-releases/helmfile.yaml.expected
+++ b/pkg/rules/factory/test_data/helmfile-nested-explicit-keep-old-releases/helmfile.yaml.expected
@@ -1,0 +1,6 @@
+filepath: ""
+helmfiles:
+- path: helmfiles/nginx/helmfile.yaml
+- path: helmfiles/jx/helmfile.yaml
+templates: {}
+renderedvalues: {}

--- a/pkg/rules/factory/test_data/helmfile-nested-explicit-keep-old-releases/helmfiles/jx/helmfile.yaml.1.expected
+++ b/pkg/rules/factory/test_data/helmfile-nested-explicit-keep-old-releases/helmfiles/jx/helmfile.yaml.1.expected
@@ -1,0 +1,11 @@
+filepath: ""
+namespace: jx
+repositories:
+- name: dev
+  url: http://chartmuseum-jx.34.78.195.22.nip.io
+releases:
+- chart: dev/myapp
+  version: 1.2.3
+  name: myapp
+templates: {}
+renderedvalues: {}

--- a/pkg/rules/factory/test_data/helmfile-nested-explicit-keep-old-releases/helmfiles/jx/helmfile.yaml.2.expected
+++ b/pkg/rules/factory/test_data/helmfile-nested-explicit-keep-old-releases/helmfiles/jx/helmfile.yaml.2.expected
@@ -1,0 +1,14 @@
+filepath: ""
+namespace: jx
+repositories:
+- name: dev
+  url: http://chartmuseum-jx.34.78.195.22.nip.io
+releases:
+- chart: dev/myapp
+  version: 1.2.3
+  name: myapp
+- chart: dev/myapp
+  version: 1.2.4
+  name: myapp
+templates: {}
+renderedvalues: {}

--- a/pkg/rules/factory/test_data/helmfile-nested-explicit-keep-old-releases/helmfiles/nginx/helmfile.yaml
+++ b/pkg/rules/factory/test_data/helmfile-nested-explicit-keep-old-releases/helmfiles/nginx/helmfile.yaml
@@ -1,0 +1,21 @@
+filepath: ""
+environments:
+  default:
+    values:
+    - ../../jx-values.yaml
+    - ../../versionStream/src/fake-secrets.yaml.gotmpl
+namespace: nginx
+repositories:
+- name: stable
+  url: https://charts.helm.sh/stable
+releases:
+- chart: stable/nginx-ingress
+  version: 1.39.1
+  name: nginx-ingress
+  values:
+  - ../../versionStream/charts/stable/nginx-ingress/values.yaml.gotmpl
+  forceNamespace: ""
+  skipDeps: null
+templates: {}
+missingFileHandler: ""
+renderedvalues: {}

--- a/pkg/rules/helmfile/helmfile_rule.go
+++ b/pkg/rules/helmfile/helmfile_rule.go
@@ -124,15 +124,16 @@ func modifyHelmfileApps(r *rules.PromoteRule, helmfile *state.HelmState, promote
 			helmfile.OverrideNamespace = promoteNs
 		}
 		found := false
-		for i := range helmfile.Releases {
-			release := &helmfile.Releases[i]
-			if release.Name == app || release.Name == details.Name {
-				release.Version = version
-				found = true
-				return nil
+		if !r.Config.Spec.HelmfileRule.KeepOldReleases {
+			for i := range helmfile.Releases {
+				release := &helmfile.Releases[i]
+				if release.Name == app || release.Name == details.Name {
+					release.Version = version
+					found = true
+					return nil
+				}
 			}
 		}
-
 		if !found {
 			ns := ""
 			if promoteNs != helmfile.OverrideNamespace {
@@ -148,12 +149,14 @@ func modifyHelmfileApps(r *rules.PromoteRule, helmfile *state.HelmState, promote
 		return nil
 	}
 	found := false
-	for i := range helmfile.Releases {
-		release := &helmfile.Releases[i]
-		if (release.Name == app || release.Name == details.Name) && (release.Namespace == promoteNs || isRemoteEnv) {
-			release.Version = version
-			found = true
-			return nil
+	if !r.Config.Spec.HelmfileRule.KeepOldReleases {
+		for i := range helmfile.Releases {
+			release := &helmfile.Releases[i]
+			if (release.Name == app || release.Name == details.Name) && (release.Namespace == promoteNs || isRemoteEnv) {
+				release.Version = version
+				found = true
+				return nil
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR implements an additional field in HelmfileRule `KeepOldReleases bool`

When this is `true` the old release will be retained in the helmfile

My primary use case for this is to use the kube api as a registry of deployed artifacts that can be consumed by apps deployed in the cluster.

For example, our java webapp uses pf4j to implement dynamically deployable/reloadable plugins.

We have two CRD 

a) PluginSet - The webapp configures the plugins that it deploys using a `PluginSet` resource.  It implements a kube informer to observe both its PluginSet and PluginRelease resources and de-deploys plugins as these change

b) PluginRelease - Defines a release of a plugin.  Which provides enough information for the plugin consumer to download the plugin.  using fields  `id` `version` `url`. This resource is deplyed to the cluster for each `pf4j plugin app` release

So when releasing we want a new instance of the `pf4j plugin app` to be added to our cluster via the helmfile.  The `pf4j plugin app` has a chart that deploys a PluginRelease resource. 