### PR TITLE
fix: lets prefer to promote with the public chart repository URL

### DIFF
--- a/pkg/promote/promote.go
+++ b/pkg/promote/promote.go
@@ -739,14 +739,14 @@ func (o *Options) ResolveChartRepositoryURL() (string, error) {
 
 	kubeClient := o.KubeClient
 	ns := o.Namespace
-	answer, err := services.FindServiceURL(kubeClient, ns, kube.ServiceChartMuseum)
+	answer, err := services.FindIngressURL(kubeClient, ns, "chartmuseum")
 	if err != nil && apierrors.IsNotFound(err) {
 		err = nil
 	}
 	if err != nil || answer == "" {
-		// lets try find a `chartmusem` ingress
+		// lets try find a `chartmusem` service instead
 		var err2 error
-		answer, err2 = services.FindIngressURL(kubeClient, ns, "chartmuseum")
+		answer, err2 = services.FindServiceURL(kubeClient, ns, kube.ServiceChartMuseum)
 		if err2 != nil && apierrors.IsNotFound(err2) {
 			err2 = nil
 		}

--- a/pkg/promote/promote_integration_test.go
+++ b/pkg/promote/promote_integration_test.go
@@ -5,8 +5,10 @@ package promote_test
 import (
 	"context"
 	jxcore "github.com/jenkins-x/jx-api/v4/pkg/apis/core/v4beta1"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/kube"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/yaml2s"
 	"github.com/roboll/helmfile/pkg/state"
+	"k8s.io/api/extensions/v1beta1"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -23,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/yaml"
 
@@ -405,6 +408,164 @@ func TestPromoteHelmfileAllAutomaticsInOneOrMorePRs(t *testing.T) {
 		t.Logf("got PipelineActivity %s\n", string(data))
 		assert.Equal(t, v1.ActivityStatusTypeSucceeded, pa.Spec.Status, "pipelineActivity.Spec.Status")
 	}
+}
+
+func TestPromoteHelmfileRemoveCluster(t *testing.T) {
+	version := "1.2.3"
+	appName := "myapp"
+	ns := "jx"
+
+	runner := NewFakeRunnerWithGitClone()
+
+	_, po := promote.NewCmdPromote()
+	name := "promote-all"
+	po.DisableGitConfig = true
+	po.Application = appName
+	po.Version = version
+	po.All = true
+
+	po.NoPoll = true
+	po.BatchMode = true
+	po.GitKind = "fake"
+	po.CommandRunner = runner.Run
+	po.AppGitURL = "https://github.com/myorg/myapp.git"
+
+	targetFullName := "jenkins-x/default-environment-helmfile"
+
+	devEnv := jxtesthelpers.CreateTestDevEnvironment(ns)
+	devGitURL := "https://github.com/jenkins-x-labs-bdd-tests/jx3-kubernetes-jenkins"
+	devEnv.Spec.Source.URL = devGitURL
+
+	chartMuseumHost := "chartmuseum-jx.1.2.3.4.nip.io"
+	kubeObjects := []runtime.Object{
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ns,
+				Labels: map[string]string{
+					"tag":  "",
+					"team": "jx",
+					"env":  "dev",
+				},
+			},
+		},
+		&v1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "chartmuseum",
+				Namespace: ns,
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: chartMuseumHost,
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: "",
+										Backend: v1beta1.IngressBackend{
+											ServiceName: kube.ServiceChartMuseum,
+											ServicePort: intstr.IntOrString{
+												IntVal: 80,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kube.ServiceChartMuseum,
+				Namespace: ns,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:     "http",
+						Protocol: "TCP",
+						Port:     80,
+					},
+				},
+			},
+		},
+	}
+	jxObjects := []runtime.Object{
+		devEnv,
+	}
+
+	po.KubeClient = fake.NewSimpleClientset(kubeObjects...)
+	po.JXClient = v1fake.NewSimpleClientset(jxObjects...)
+	po.Namespace = ns
+	po.Build = "1"
+	po.Pipeline = "myorg/myapp/master"
+	po.DevEnvContext.VersionResolver = jxtesthelpers.CreateTestVersionResolver(t)
+	po.DevEnvContext.Requirements = &jxcore.RequirementsConfig{
+		Environments: []jxcore.EnvironmentConfig{
+			{
+				Key:               "dev",
+				Namespace:         "jx",
+				PromotionStrategy: v1.PromotionStrategyTypeNever,
+				GitURL:            devGitURL,
+			},
+			{
+				Key:               "production",
+				Namespace:         "prodns",
+				PromotionStrategy: v1.PromotionStrategyTypeAutomatic,
+				Owner:             "jstrachan",
+				Repository:        "jx-demo-gke2-prod",
+				RemoteCluster:     true,
+			},
+		},
+	}
+
+	err := po.Run()
+	require.NoError(t, err, "failed test %s s", name)
+
+	require.DirExists(t, po.OutDir, "should have an output dir from the generated PR")
+	promotedHelmfile := filepath.Join(po.OutDir, "helmfiles", "prodns", "helmfile.yaml")
+	require.FileExists(t, promotedHelmfile, "should have created the helmfile in the promote namespace")
+	t.Logf("created promotion helmfile %s\n", promotedHelmfile)
+
+	// lets verify we used the correct helm chart URL
+	helmState := &state.HelmState{}
+	err = yaml2s.LoadFile(promotedHelmfile, helmState)
+	require.NoError(t, err, "failed to load helmfile %s", promotedHelmfile)
+
+	require.Len(t, helmState.Repositories, 1, "should have 1 repository for %s", promotedHelmfile)
+	helmRepo := helmState.Repositories[0]
+	t.Logf("promoted with helm repository %s = %s in file %s\n", helmRepo.Name, helmRepo.URL, promotedHelmfile)
+
+	assert.Equal(t, "dev", helmRepo.Name, "repositories[0].name for %s", promotedHelmfile)
+	assert.Equal(t, "http://"+chartMuseumHost, helmRepo.URL, "repositories[0].url for %s", promotedHelmfile)
+
+	scmClient := po.ScmClient
+	require.NotNil(t, scmClient, "no ScmClient created")
+	ctx := context.Background()
+
+	prNumber := 1
+	pr, _, err := scmClient.PullRequests.Find(ctx, targetFullName, prNumber)
+	require.NoError(t, err, "failed to find repository %s number %d", targetFullName, prNumber)
+	assert.NotNil(t, pr, "nil pr %s for %s", targetFullName, prNumber)
+
+	t.Logf("created PullRequest %s #%d", pr.Link, prNumber)
+	t.Logf("PR title: %s", pr.Title)
+	t.Logf("PR body: %s", pr.Body)
+
+	// lets assert we have a PipelineActivity...
+	paList, err := po.JXClient.JenkinsV1().PipelineActivities(ns).List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err, "failed to load PipelineActivity resources in namespace %s", ns)
+	require.Len(t, paList.Items, 1, "should have a PipelineActivity in namespace %s", ns)
+	pa := paList.Items[0]
+
+	data, err := yaml.Marshal(pa)
+	require.NoError(t, err, "failed to marshal PipelineActivity")
+
+	t.Logf("got PipelineActivity %s\n", string(data))
+	assert.Equal(t, v1.ActivityStatusTypeSucceeded, pa.Spec.Status, "pipelineActivity.Spec.Status")
+
 }
 
 func TestPromoteHelmfileToNamedLocalEnvironment(t *testing.T) {


### PR DESCRIPTION
and add a unit test to check that works. Then we're more likely to work on remote clusters and handle local builds too