### PR TITLE
fix: improve the remote chart repository detection

### DIFF
--- a/pkg/promote/promote_integration_test.go
+++ b/pkg/promote/promote_integration_test.go
@@ -410,7 +410,7 @@ func TestPromoteHelmfileAllAutomaticsInOneOrMorePRs(t *testing.T) {
 	}
 }
 
-func TestPromoteHelmfileRemoveCluster(t *testing.T) {
+func TestPromoteHelmfileRemoteCluster(t *testing.T) {
 	version := "1.2.3"
 	appName := "myapp"
 	ns := "jx"
@@ -503,6 +503,11 @@ func TestPromoteHelmfileRemoveCluster(t *testing.T) {
 	po.Pipeline = "myorg/myapp/master"
 	po.DevEnvContext.VersionResolver = jxtesthelpers.CreateTestVersionResolver(t)
 	po.DevEnvContext.Requirements = &jxcore.RequirementsConfig{
+		Cluster: jxcore.ClusterConfig{
+			DestinationConfig: jxcore.DestinationConfig{
+				ChartRepository: "http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080",
+			},
+		},
 		Environments: []jxcore.EnvironmentConfig{
 			{
 				Key:               "dev",

--- a/pkg/promote/promote_test.go
+++ b/pkg/promote/promote_test.go
@@ -160,3 +160,17 @@ func TestConvertToGitHubPagesURL(t *testing.T) {
 	require.Error(t, err, "should fail to convert to github pages URL %s", source)
 	t.Logf("got expected failure %s for %s\n", err.Error(), source)
 }
+
+func TestIsLocalChartRepository(t *testing.T) {
+	localRepos := []string{"http://jenkins-x-chartmuseum:8080", "http://jenkins-x-chartmuseum", "https://chartmuseum", "http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080", "http://bucketrepo.jx"}
+	for _, repo := range localRepos {
+		actual := promote.IsLocalChartRepository(repo)
+		assert.True(t, actual, "should be local repo %s", repo)
+	}
+
+	remoteRepos := []string{"http://foo.bar", "https://chartrepo.mydomain.com"}
+	for _, repo := range remoteRepos {
+		actual := promote.IsLocalChartRepository(repo)
+		assert.False(t, actual, "not local repo %s", repo)
+	}
+}


### PR DESCRIPTION
so we avoid using local service names in promotion URLs if we know the repository