### PR TITLE
fix: Reuse pull request

### DIFF
--- a/pkg/environments/pr.go
+++ b/pkg/environments/pr.go
@@ -129,7 +129,12 @@ func (o *EnvironmentPullRequestOptions) CreatePullRequest(scmClient *scm.Client,
 	head := headPrefix + o.BranchName
 
 	if existingPR != nil {
-		return o.addLabelsToPullRequest(ctx, scmClient, repoFullName, existingPR)
+		prInput := &scm.PullRequestInput{
+			Title: commitTitle,
+			Body:  commitBody,
+		}
+		existingPR, _, err = scmClient.PullRequests.Update(ctx, repoFullName, existingPR.Number, prInput)
+		return existingPR, errors.Wrapf(err, "failed to update PullRequest %+v with %+v", existingPR, prInput)
 	}
 	pri := &scm.PullRequestInput{
 		Title: commitTitle,

--- a/pkg/environments/types.go
+++ b/pkg/environments/types.go
@@ -56,11 +56,11 @@ type EnvironmentPullRequestOptions struct {
 	BatchMode              bool
 	UseGitHubOAuth         bool
 	Fork                   bool
+	ReusePullRequest       bool
 	SparseCheckoutPatterns []string
 }
 
 // A PullRequestFilter defines a filter for finding pull requests
 type PullRequestFilter struct {
 	Labels []string
-	Number *int
 }

--- a/pkg/promote/promote.go
+++ b/pkg/promote/promote.go
@@ -673,11 +673,7 @@ func (o *Options) Promote(envs []*jxcore.EnvironmentConfig, warnIfAuto, noPoll b
 			if !envIsPermanent(env) {
 				return nil, errors.Errorf("cannot promote to Environment which is not a permanent Environment")
 			}
-			if env.ReusePullRequest {
-				o.PullRequestFilter = &environments.PullRequestFilter{Labels: []string{"dependency/" + fullAppName}}
-			} else {
-				o.PullRequestFilter = nil
-			}
+			o.ReusePullRequest = env.ReusePullRequest
 
 			sourceURL := requirements.EnvironmentGitURL(o.DevEnvContext.Requirements, env.Key)
 			if sourceURL == "" && !env.RemoteCluster && o.DevEnvContext.DevEnv != nil {


### PR DESCRIPTION
This is a follow up to my activation of the reuse pull request feature.

The most crucial fix is of the check that pr is not made from fork. It previously filtered away all PRs.
Update of title and body of reused PR is added.
I changed the labels filtering so it filters for the same labels as we set on pr (without this a PR for the wrong env might be reused)
I left the the debug and trace output from the development; it might be useful for others.

I tested this by setting `reusePullRequest: true` for an environment in `.jx/settings.yaml`. My git provider is github. So at least that is now verified to work.