### PR TITLE
Fixes to ease migration to oci

### DIFF
--- a/pkg/rules/helmfile/helmfile_rule.go
+++ b/pkg/rules/helmfile/helmfile_rule.go
@@ -152,7 +152,9 @@ func modifyHelmfileApps(r *rules.PromoteRule, helmStates []*state.HelmState, pro
 	}
 
 	if highestScore > 0 {
-		highestScorer.Version = r.Version
+		highestScorer.Version = version
+		// The repository might have changed, so updating Chart
+		highestScorer.Chart = details.Name
 	} else {
 		newReleaseName := details.LocalName
 		if r.ReleaseName != "" {

--- a/pkg/rules/helmfile/helmfile_rule.go
+++ b/pkg/rules/helmfile/helmfile_rule.go
@@ -250,8 +250,8 @@ func defaultPrefix(helmStates []*state.HelmState, envctx *envctx.EnvironmentCont
 	oci := false
 	//  we need to remove the oci:// prefix (in case it exists), because helmfile doesn't support the scheme in the repo url for oci based repositories.
 	//  for these repositories, only url without a scheme and the oci: true flag is needed.
-	d.Repository = strings.TrimPrefix(d.Repository, "oci://")
-	if envctx.Requirements != nil {
+	d.Repository, oci = strings.CutPrefix(d.Repository, "oci://")
+	if !oci && envctx.Requirements != nil {
 		oci = envctx.Requirements.Cluster.ChartKind == jxcore.ChartRepositoryTypeOCI
 	}
 	prefixes := map[string]string{}


### PR DESCRIPTION
This PR adds support for specifying oci chart with --helm-repo-url and not setting chartKind=oci in requirements and
changing repository for chart in helmfile.

__What happended__

When testing promotion of chart pushed to oci registry by explicitly specifying  --helm-repo-url I got PR with a change like this:

```diff
diff --git a/helmfiles/jx-test/helmfile.yaml b/helmfiles/jx-test/helmfile.yaml
index 322d05c5f9..9f3f747ec9 100644
--- a/helmfiles/jx-test/helmfile.yaml
+++ b/helmfiles/jx-test/helmfile.yaml
@@ -9,6 +9,8 @@ repositories:
   url: s3://chartmuseum.ticket.se/jx3
 - name: k8s-helm
   url: https://codiway-com.github.io/k8s-helm/
+- name: dev
+  url: xxxxxxxx.dkr.ecr.eu-north-1.amazonaws.com/charts
 releases:
 - chart: local/another-app
   version: 1.5.8
@@ -577,7 +579,7 @@ releases:
   values:
   - jx-values
 - chart: local/myapp
-  version: 0.2.64
+  version: 0.2.67
   name: relnotes
   values:
   - jx-values.yaml
```

__What should have happended__

The PR should have looked like this and with this PR it would:

```diff
diff --git a/helmfiles/jx-test/helmfile.yaml b/helmfiles/jx-test/helmfile.yaml
index 322d05c5f9e..18975f77336 100644
--- a/helmfiles/jx-test/helmfile.yaml
+++ b/helmfiles/jx-test/helmfile.yaml
@@ -9,6 +9,9 @@ repositories:
   url: s3://chartmuseum.ticket.se/jx3
 - name: k8s-helm
   url: https://codiway-com.github.io/k8s-helm/
+- name: dev
+  url: xxxxxxxx.dkr.ecr.eu-north-1.amazonaws.com/charts
+  oci: true
 releases:
 - chart: local/another-app
   version: 1.5.8
@@ -576,8 +579,8 @@ releases:
   values:
   - jx-values
-- chart: local/myapp
-  version: 0.2.64
+- chart: dev/myapp
+  version: 0.2.67
   name: relnotes
   values:
   - jx-values.yaml
```