### PR TITLE
chore: upgrade go 1.26.3

### DIFF
--- a/.github/workflows/jenkins-x-pr.yaml
+++ b/.github/workflows/jenkins-x-pr.yaml
@@ -7,14 +7,14 @@ jobs:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       name: build-make-linux
-      uses: docker://golang:1.24.4
+      uses: docker://golang:1.26.3
       with:
         args: -c "make linux"
         entrypoint: /bin/sh
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       name: build-make-test
-      uses: docker://golang:1.24.4
+      uses: docker://golang:1.26.3
       with:
         args: -c "make test"
         entrypoint: /bin/sh

--- a/.github/workflows/jenkins-x-release.yaml
+++ b/.github/workflows/jenkins-x-release.yaml
@@ -22,7 +22,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GIT_BOT_TOKEN }}
         VERSION: ${{ steps.prep.outputs.version }}
       name: release-binary
-      uses: docker://golang:1.24.4
+      uses: docker://golang:1.26.3
       with:
         args: -c "make release"
         entrypoint: bash

--- a/.github/workflows/jenkins-x-release.yaml
+++ b/.github/workflows/jenkins-x-release.yaml
@@ -38,7 +38,7 @@ jobs:
         REPOSITORY: ${{ github.repository }}
         VERSION: ${{ steps.prep.outputs.version }}
       name: upload-binaries
-      uses: docker://ghcr.io/jenkins-x/jx-goreleaser-image:1.0.2@sha256:7632b381687494e910e06a88b3801e39c1f17fbb44402db3cef45b2b342204e1
+      uses: docker://ghcr.io/jenkins-x/jx-goreleaser-image:1.0.3@sha256:f304b286bf8c0995b8161172eb54ab12bcd744f89caf71fc3a91329de87a3b4f
       with:
         entrypoint: .github/workflows/jenkins-x/upload-binaries.sh
     - name: Set up QEMU

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,97 +1,109 @@
-linters-settings:
-  depguard:
-    rules:
-      # Name of a rule.
-      Main:
-        list-mode: lax
-        deny:
-        - pkg: github.com/jenkins-x/jx/v2/pkg/log/
-          desc:  "use jenkins-x/jx-logging instead"
-        - pkg: github.com/satori/go.uuid
-          desc: "use github.com/google/uuid instead"
-        - pkg: github.com/pborman/uuid
-          desc: "use github.com/google/uuid instead"
-  dupl:
-    threshold: 100
-  exhaustive:
-    default-signifies-exhaustive: false
-  funlen:
-    lines: 200
-    statements: 150
-  goconst:
-    min-len: 3
-    min-occurrences: 3
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-      - wrapperFunc
-      - importShadow # not important for now
-      - unnamedResult # not important
-  gocyclo:
-    min-complexity: 15
-  goimports: {}
-  revive:
-    confidence: 0
-  gofmt:
-    simplify: true
-  mnd:
-    # don't include the "operation" and "assign"
-    checks: [argument, case, condition, return]
-  govet:
-    settings:
-      printf:
-        funcs:
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Debugf
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Infof
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Warnf
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Errorf
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Fatalf
-  lll:
-    line-length: 140
-  misspell: {}
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+version: "2"
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - asciicheck
     - bodyclose
     - depguard
     - errcheck
-    - gofmt
-    - goimports
+    - gocritic
     - goprintffuncname
     - gosec
-    - gosimple
+    - govet
     - ineffassign
     - misspell
     - nakedret
+    - revive
     - rowserrcheck
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
-    - revive
-    - gocritic
-    - govet
-issues:
-  exclude-dirs:
-  - cmd/docs
-run:
-  timeout: 1h30m
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
+  settings:
+    depguard:
+      rules:
+        Main:
+          list-mode: lax
+          deny:
+            - pkg: github.com/jenkins-x/jx/v2/pkg/log/
+              desc: use jenkins-x/jx-logging instead
+            - pkg: github.com/satori/go.uuid
+              desc: use github.com/google/uuid instead
+            - pkg: github.com/pborman/uuid
+              desc: use github.com/google/uuid instead
+    dupl:
+      threshold: 100
+    exhaustive:
+      default-signifies-exhaustive: false
+    funlen:
+      lines: 200
+      statements: 150
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - whyNoLint
+        - wrapperFunc
+        - importShadow
+        - unnamedResult
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 15
+    govet:
+      settings:
+        printf:
+          funcs:
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Debugf
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Infof
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Warnf
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Errorf
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Fatalf
+    lll:
+      line-length: 140
+    mnd:
+      checks:
+        - argument
+        - case
+        - condition
+        - return
+    nolintlint:
+      require-explanation: false
+      require-specific: false
+      allow-unused: false
+    revive:
+      confidence: 0
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - cmd/docs
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - cmd/docs
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ROOT_PACKAGE := github.com/$(ORG_REPO)
 # This does not reflect the go binary version which was used to build the jx binary, and also does not reflect the version in the catalog.
 # The sole purpose of this variable is to build a new binary if we ever need to build a new jx binary with a new go version with no code change.
 # If you notice that this version is not the same as the catalog version, please open a PR, the maintainers are happy to review it.
-DUMMY_GO_VERSION := 1.18.6
+DUMMY_GO_VERSION := 1.26.3
 
 GO_VERSION := $(shell $(GO) version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/')
 

--- a/go.mod
+++ b/go.mod
@@ -332,4 +332,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 )
 
-go 1.24.4
+go 1.26.3

--- a/pkg/rules/file/file_rule.go
+++ b/pkg/rules/file/file_rule.go
@@ -99,6 +99,7 @@ func Rule(r *rules.PromoteRule) error {
 	}
 
 	data = []byte(strings.Join(lines, "\n"))
+	// #nosec G703 -- path is constructed from trusted promote rule configuration
 	err = os.WriteFile(path, data, files.DefaultFileWritePermissions)
 	if err != nil {
 		return fmt.Errorf("failed to write file %s: %w", path, err)


### PR DESCRIPTION
- upgrade to go 1.26.3
- upgrade golangci-lint to version 2
- part of https://github.com/jenkins-x/jx/issues/8965